### PR TITLE
#4 Simplify version identifier.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     <name>${project.name}</name>
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
-    <version>4.0.6 Release 1</version>
+    <version>${project.version}</version>
     <date>(TBD)</date>
     <minServerVersion>4.1.5</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>inverse</artifactId>
-    <version>4.0.6-release-1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <name>inVerse</name>
     <description>Adds the (third-party, Converse-based) inVerse web client to Openfire.</description>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>inverse</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.1.0.1-SNAPSHOT</version>
     <name>inVerse</name>
     <description>Adds the (third-party, Converse-based) inVerse web client to Openfire.</description>
     <build>


### PR DESCRIPTION
Up until now, the version identifier was formatted as:

    <major>.<minor>.<patch> RELEASE <increment>

where everything before 'release' matches the version of the upstream
Converse dependency. This format proves difficult to work with, as it
doesn't play nice with the combination of IgniteRealtime website, Maven,
and Openfire-based version identifier parsing.

This commit reverts back to a simpler format. We'll have to figure out
a different way to denote multiple builds based on the same version of
Converse (but to date, that hasn't happened yet - jinxing it as I write
this).