### PR TITLE
fixes #44: Stop using deprecated Openfire API

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,11 @@
     inVerse Plugin Changelog
 </h1>
 
+<p><b>9.0.0 Release 2</b> -- (tbd)</p>
+<ul>
+    <li><a href="https://github.com/igniterealtime/openfire-inverse-plugin/issues/44">#44</a>: Replace usage of deprecated Openfire API.
+</ul>
+
 <p><b>9.0.0 Release 1</b> -- December 1, 2021</p>
 <ul>
     <li><a href="https://github.com/igniterealtime/openfire-inverse-plugin/issues/42">#42: Update to Converse 9.0.0</a>, which includes these changes:

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>12/01/2021</date>
+    <date>2022-02-17</date>
     <minServerVersion>4.1.5</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <adminconsole>

--- a/src/web/inverse-config.jsp
+++ b/src/web/inverse-config.jsp
@@ -24,6 +24,8 @@
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
 <%@ page import="java.net.URLEncoder" %>
+<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
+<%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
@@ -173,14 +175,14 @@
         <fmt:param value=""/>
     </fmt:message>
     <% if ( httpBindManager.isHttpBindActive() ) {
-        final String unsecuredAddress = "http://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + httpBindManager.getHttpBindUnsecurePort() + "/inverse/";
+        final String unsecuredAddress = "http://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + ((ConnectionManagerImpl)XMPPServer.getInstance().getConnectionManager()).getPort(ConnectionType.BOSH_C2S, false) + "/inverse/";
     %>
         <fmt:message key="config.page.link.unsecure">
             <fmt:param value="<%=unsecuredAddress%>"/>
         </fmt:message>
     <% } %>
     <% if ( httpBindManager.isHttpsBindActive() ) {
-        final String securedAddress = "https://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + httpBindManager.getHttpBindSecurePort() + "/inverse/";
+        final String securedAddress = "https://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + ((ConnectionManagerImpl)XMPPServer.getInstance().getConnectionManager()).getPort(ConnectionType.BOSH_C2S, true) + "/inverse/";
     %>
         <fmt:message key="config.page.link.secure">
             <fmt:param value="<%=securedAddress%>"/>


### PR DESCRIPTION
Replaces calls to Openfire's API that have been deprecated. This should prevent issues when that code is removed from Openfire (likely to happen in Openfire 4.8.0 as part of OF-2395).