### PR TITLE
Release 10.1.7 2

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,7 +43,7 @@
     inVerse Plugin Changelog
 </h1>
 
-<p><b>10.1.7 Release 2</b> -- (to be determined)</p>
+<p><b>10.1.7 Release 2</b> -- November 14, 2024</p>
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
 </ul>

--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,11 @@
     inVerse Plugin Changelog
 </h1>
 
+<p><b>10.1.7 Release 2</b> -- (to be determined)</p>
+<ul>
+    <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
+</ul>
+
 <p><b>10.1.7 Release 1</b> -- March 15, 2024</p>
 <ul>
     <li>Bump org.json:json from 20230227 to 20231013</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,8 +5,9 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2024-03-15</date>
+    <date>2024-11-14</date>
     <minServerVersion>4.1.5</minServerVersion>
+    <priorToServerVersion>5.0.0</priorToServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="inverse-config.jsp">

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>inverse</artifactId>
-    <version>10.1.7.2</version>
+    <version>10.1.7.3-SNAPSHOT</version>
     <name>inVerse</name>
     <description>Adds the (third-party, Converse-based) inVerse web client to Openfire.</description>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>inverse</artifactId>
-    <version>10.1.7.2-SNAPSHOT</version>
+    <version>10.1.7.2</version>
     <name>inVerse</name>
     <description>Adds the (third-party, Converse-based) inVerse web client to Openfire.</description>
     <build>


### PR DESCRIPTION
Adds 'prior to' restriction to reflect incompatibility with Openfire 5.0.0 and later (because of the Jetty upgrade).