### PR TITLE
Use static version identifier for Openfire dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.0-beta</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>inverse</artifactId>


### PR DESCRIPTION
Instead of depending on 5.0.0-SNAPSHOT, use a version identifier that is deterministic.